### PR TITLE
Invoke-NextcloudApi and Users fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,52 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}"
+        },
+        {
+            "name": "PowerShell Launch Current File in Temporary Console",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}",
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "name": "PowerShell Launch Current File w/Args Prompt",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "args": [
+                "${command:SpecifyScriptArgs}"
+            ],
+            "cwd": "${file}"
+        },
+        {
+            "name": "PowerShell Attach to Host Process",
+            "type": "PowerShell",
+            "request": "attach"
+        },
+        {
+            "name": "PowerShell Interactive Session",
+            "type": "PowerShell",
+            "request": "launch",
+            "cwd": ""
+        },
+        {
+            "name": "PowerShell Attach Interactive Session Runspace",
+            "type": "PowerShell",
+            "request": "attach",
+            "processId": "current"
+        }
+    ]
+}

--- a/Tests/Users.Tests.ps1
+++ b/Tests/Users.Tests.ps1
@@ -1,0 +1,11 @@
+Import-Module .\Nextcloud.psd1 -Force
+
+$User = 'Me'
+$Credential = Get-Credential $User
+
+Connect-NextcloudServer -Server nextcloud-dev.powershellonlinux.com -Credential $Credential
+
+Get-NextcloudUser -UserID $User
+Set-NextcloudUser -Email 'zoby101@gmail.com' -UserID $User
+Add-NextcloudUser -UserID "$User-Test1" -Password New-Guid
+Remove-NextcloudUser -UserID "$User-Test1"


### PR DESCRIPTION
* added internal function Invoke-NextcloudApi to simplify the code. 
* Connect-NextcloudServer uses -Credential as password parameter is not recommended.
* Change connection variables  Global to Script to keep the user thread clean.
* Get-NextcloudUser -UserID like in other commands for consistency.
* Get-NextcloudUser now return PSObject instead of XmlElement.

